### PR TITLE
Enable more use of LLVM infrastructure.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,24 @@
 cmake_minimum_required(VERSION 3.10)
 
-project(standalone-dialect LANGUAGES CXX)
+if(POLICY CMP0068)
+  cmake_policy(SET CMP0068 NEW)
+  set(CMAKE_BUILD_WITH_INSTALL_NAME_DIR ON)
+endif()
+
+if(POLICY CMP0075)
+  cmake_policy(SET CMP0075 NEW)
+endif()
+
+if(POLICY CMP0077)
+  cmake_policy(SET CMP0077 NEW)
+endif()
+
+project(standalone-dialect LANGUAGES CXX C)
 
 find_package(MLIR REQUIRED CONFIG)
+
+message(STATUS "Using MLIRConfig.cmake in: ${MLIR_DIR}")
+message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 
 set(LLVM_RUNTIME_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/bin)
 set(LLVM_LIBRARY_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/lib)
@@ -13,8 +29,13 @@ list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
 include(TableGen)
 include(AddLLVM)
 include(AddMLIR)
+include(HandleLLVMOptions)
 
 include_directories(${LLVM_INCLUDE_DIRS})
+include_directories(${MLIR_INCLUDE_DIRS})
+include_directories(${PROJECT_SOURCE_DIR}/include)
+include_directories(${PROJECT_BINARY_DIR}/include)
+link_directories(${LLVM_BUILD_LIBRARY_DIR})
 add_definitions(${LLVM_DEFINITIONS})
 
 add_subdirectory(include)

--- a/lib/Standalone/CMakeLists.txt
+++ b/lib/Standalone/CMakeLists.txt
@@ -10,6 +10,3 @@ add_mlir_dialect_library(MLIRStandalone
         )
 
 target_link_libraries(MLIRStandalone PUBLIC MLIRIR)
-
-target_include_directories(MLIRStandalone PUBLIC "${PROJECT_SOURCE_DIR}/include")
-target_include_directories(MLIRStandalone PUBLIC "${PROJECT_BINARY_DIR}/include")


### PR DESCRIPTION
1) It's really easy to misconfigure and silently build against an unintended
LLVM: print out where the configuration comes from.

2) Include HandleLLVMOptions, which deals with most standard LLVM configuration options.  This also requires C.

3) Set consistent cmake policies so that we don't get spurious warnings.

4) Point to MLIR_INCLUDE_DIRS, so we can include OpBase.td

5) include dialect-specific includes globally in this project, to be more consitstent with MLIR.