### PR TITLE
Use add_llvm_executable instead of add_llvm_tool.

### DIFF
--- a/standalone-opt/CMakeLists.txt
+++ b/standalone-opt/CMakeLists.txt
@@ -33,7 +33,7 @@ set(LIBS
 
         MLIRStandalone
         )
-add_llvm_tool(standalone-opt standalone-opt.cpp)
+add_llvm_executable(standalone-opt standalone-opt.cpp)
 
 # Manually expand the target library, since our MLIR libraries
 # aren't plugged into the LLVM dependency tracking. If we don't


### PR DESCRIPTION
add_llvm_tool has some extra configurability that can exclude it from the ALL
target.  We don't really want to include all of the llvm configuration
machinery in llvm/CMakeLists.txt, but withouht this machinery, the default
is to exclude from the ALL target.  This change results in standalone-opt
getting built even if the tests are not run.